### PR TITLE
Fix #12 - SingularityCE version not recognised

### DIFF
--- a/test/test_expression.yml
+++ b/test/test_expression.yml
@@ -55,8 +55,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-expression-integration-HEL
   tags:

--- a/test/test_fusion.yml
+++ b/test/test_fusion.yml
@@ -81,8 +81,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-fusion-integration-NB-4-dry-run
   tags:

--- a/test/test_hamlet.yml
+++ b/test/test_hamlet.yml
@@ -53,8 +53,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-hamlet-frankenstein-integration
   tags:

--- a/test/test_itd.yml
+++ b/test/test_itd.yml
@@ -59,8 +59,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-itd-MV4-11-flt3
   tags:

--- a/test/test_qc_seq.yml
+++ b/test/test_qc_seq.yml
@@ -35,8 +35,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-qc-single
   tags:

--- a/test/test_snv_indels.yml
+++ b/test/test_snv_indels.yml
@@ -49,8 +49,8 @@
   command: >
     singularity --version
   stdout:
-    contains:
-      - "singularity version 3"
+    contains_regex:
+      - "singularity(-ce)? version 3"
 
 - name: test-p53-integration-NB-4
   tags:


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [x] Documentation was updated (if required).
- [x] New test have been properly tagged with the test (`sanity`, `dry-run` or
      `intergration`) **and** the apropriate module (`qc`, `itd`, `fusion`,
      `expression`, `snv-indels` or `hamlet`).
