### PR TITLE
workaround for invalid hgvs

### DIFF
--- a/includes/snv-indels/scripts/filter_vep.py
+++ b/includes/snv-indels/scripts/filter_vep.py
@@ -204,14 +204,11 @@ class Criterion:
         return str(self)
 
     def match(self, variant: Variant) -> bool:
-        return all(
-            [
-                self.match_id(variant),
-                self.match_coordinate(variant),
-                self.match_consequence(variant),
-                self.match_region(variant),
-            ]
-        )
+        return (self.match_id(variant) and
+                self.match_coordinate(variant) and
+                self.match_consequence(variant) and
+                self.match_region(variant)
+                )
 
     def match_id(self, variant: Variant) -> bool:
         """Determine if the identifier matches the variant


### PR DESCRIPTION
Adapted match function to prevent Mutalyzer error on hgvs with invalid description *-
Match function now exits when any match returns False.